### PR TITLE
Feature/jvisenti/optional delegate methods

### DIFF
--- a/RZTouchID/RZTouchID.h
+++ b/RZTouchID/RZTouchID.h
@@ -39,6 +39,8 @@
  */
 @protocol RZTouchIDDelegate <NSObject>
 
+@optional
+
 /**
  *  Called by deletePasswordWithIdentifier:completion: 
  * 

--- a/RZTouchID/RZTouchID.h
+++ b/RZTouchID/RZTouchID.h
@@ -118,7 +118,11 @@ typedef NS_ENUM(NSUInteger, RZTouchIDError){
      */
     RZTouchIDErrorItemNotFound,
     /**
-     *  Touch ID authentication failure - either user cancelled, user hit the fallback option, system cancelled auth (e.g. another app came to foreground) or the user failed to match their fingerprint or passcode
+     *  User canceled the system prompt to authenticate with Touch ID.
+     */
+    RZTouchIDErrorUserCanceled,
+    /**
+     *  Touch ID authentication failure - either user hit the fallback option, system cancelled auth (e.g. another app came to foreground) or the user failed to match their fingerprint or passcode
      */
     RZTouchIDErrorAuthenticationFailed,
     /**

--- a/RZTouchID/RZTouchID.m
+++ b/RZTouchID/RZTouchID.m
@@ -65,7 +65,7 @@ NSString* const kRZTouchIDErrorDomain = @"com.raizlabs.touchID";
 
 - (BOOL)touchIDAvailableForIdentifier:(NSString *)identifier
 {
-    return ( identifier != nil && identifier.length > 0 && [self.class touchIDAvailable] && [self.delegate touchID:self shouldAddPasswordForIdentifier:identifier] );
+    return (identifier != nil && identifier.length > 0 && [self.class touchIDAvailable] && (![self.delegate respondsToSelector:@selector(touchID:shouldAddPasswordForIdentifier:)] || [self.delegate touchID:self shouldAddPasswordForIdentifier:identifier]));
 }
 
 - (instancetype)initWithKeychainServicePrefix:(NSString *)servicePrefix authenticationMode:(RZTouchIDMode)touchIDMode
@@ -119,7 +119,7 @@ NSString* const kRZTouchIDErrorDomain = @"com.raizlabs.touchID";
 
             if ( completion != nil ) {
                 dispatch_async(self.completionQueue, ^{
-                    if ( error == nil ) {
+                    if ( error == nil && [self.delegate respondsToSelector:@selector(touchID:didAddPasswordForIdentifier:)] ) {
                         [self.delegate touchID:self didAddPasswordForIdentifier:identifier];
                     }
                     completion(password, error);
@@ -171,7 +171,7 @@ NSString* const kRZTouchIDErrorDomain = @"com.raizlabs.touchID";
         if ( completion != nil ) {
             dispatch_async(self.completionQueue, ^{
                 // If we don't find the item in the keychain, it has the same net result as success
-                if ( error == nil || error.code == RZTouchIDErrorItemNotFound ) {
+                if ( (error == nil || error.code == RZTouchIDErrorItemNotFound) && [self.delegate respondsToSelector:@selector(touchID:didDeletePasswordForIdentifier:)] ) {
                     [self.delegate touchID:self didDeletePasswordForIdentifier:identifier];
                 }
                 completion(nil, error);

--- a/RZTouchID/RZTouchID.m
+++ b/RZTouchID/RZTouchID.m
@@ -284,6 +284,11 @@ NSString* const kRZTouchIDErrorDomain = @"com.raizlabs.touchID";
                 rzTouchIDError = RZTouchIDErrorItemNotFound;
                 break;
             }
+            case errSecUserCanceled: {
+                msg = NSLocalizedString(@"ERROR_USER_CANCELED", nil);
+                rzTouchIDError = RZTouchIDErrorUserCanceled;
+                break;
+            }
             case errSecAuthFailed: {
                 msg = NSLocalizedString(@"ERROR_ITEM_AUTHENTICATION_FAILED", nil);
                 rzTouchIDError = RZTouchIDErrorAuthenticationFailed;


### PR DESCRIPTION
- Changed `RZTouchIDDelegate` methods to be optional
- If no delegate is specified, `RZTouchID` now assumes `YES` for `touchIDAvailableForIdentifier:`
- Added a new error code to distinguish between auth failure and user cancelation
